### PR TITLE
Remove matching query plan hashes from metrics

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "c:\\Users\\angela\\sqlserver-plan-regression-monitor\\venv\\Scripts\\python.exe"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "c:\\Users\\angela\\sqlserver-plan-regression-monitor\\venv\\Scripts\\python.exe"
+}

--- a/plan_monitor/detect.py
+++ b/plan_monitor/detect.py
@@ -53,16 +53,16 @@ def find_bad_plans(plans: Dict[str, Dict], stats_time: int) -> Tuple[List[Dict[s
         if plan_age_seconds < config.MIN_NEW_PLAN_AGE_SECONDS:
             # too new; ignore entirely for now. If it's a problem we'll catch it on next poll
             continue
-        elif is_established_plan(plan_age_seconds, last_exec_age_seconds) and \
-            current_query_plan_hash not in potential_bad_query_plan_hashes:
+        elif is_established_plan(plan_age_seconds, last_exec_age_seconds):
             # this is an old or "established" plan; gather its stats but don't consider it for "badness"
             prior_plans.append(plan_stats)
-            prior_plans_count += 1
-            prior_times += plan_stats['total_elapsed_time']
-            prior_reads += plan_stats['total_logical_reads']
-            prior_execs += plan_stats['execution_count']
-            prior_worst_plan_hashes.add(current_query_plan_hash)
-            prior_last_execution = max(prior_last_execution, plan_stats['last_execution_time'])
+            if current_query_plan_hash not in potential_bad_query_plan_hashes:
+                prior_plans_count += 1
+                prior_times += plan_stats['total_elapsed_time']
+                prior_reads += plan_stats['total_logical_reads']
+                prior_execs += plan_stats['execution_count']
+                prior_worst_plan_hashes.add(current_query_plan_hash)
+                prior_last_execution = max(prior_last_execution, plan_stats['last_execution_time'])
             continue
         elif plan_stats['total_elapsed_time'] < config.MIN_TOTAL_ELAPSED_TIME_SECONDS * 1_000_000 \
                 and plan_stats['total_logical_reads'] < config.MIN_TOTAL_LOGICAL_READS:

--- a/plan_monitor/detect.py
+++ b/plan_monitor/detect.py
@@ -23,7 +23,7 @@ def calculate_plan_age_stats(plan_stats: Dict[str, Any], stats_time: int) -> Tup
 
 def is_established_plan(plan_age_seconds: int, last_exec_age_seconds: int) -> bool:
     return plan_age_seconds > config.MAX_NEW_PLAN_AGE_SECONDS or \
-            last_exec_age_seconds > config.MAX_AGE_OF_LAST_EXECUTION_SECONDS
+        last_exec_age_seconds > config.MAX_AGE_OF_LAST_EXECUTION_SECONDS
 
 def is_plan_under_investigation(plan_stats: Dict[str, Any], stats_time: int) -> bool:
     plan_age_seconds, last_exec_age_seconds = calculate_plan_age_stats(plan_stats, stats_time)

--- a/plan_monitor/detect.py
+++ b/plan_monitor/detect.py
@@ -153,7 +153,6 @@ def detect() -> None:
 
     kafka_producer = confluent_kafka.SerializingProducer(producer_config)
     kafka_consumer = confluent_kafka.DeserializingConsumer(consumer_config)
-    # here we subscribe to the topic we've created to queue stats for processing
     kafka_consumer.subscribe(
         [config.STATS_TOPIC], on_assign=partial(common.set_offsets_to_time, config.REFRESH_INTERVAL_MINUTES * 60))
 

--- a/plan_monitor/detect.py
+++ b/plan_monitor/detect.py
@@ -75,6 +75,7 @@ def find_bad_plans(plans: Dict[str, Dict], stats_time: int) -> Tuple[List[Dict[s
         else:
             candidate_bad_plans.append(plan_stats)
 
+    # need enough executions prior plans to be able to trust them as a point of comparison
     if prior_plans_count and candidate_bad_plans and prior_execs > config.MIN_EXECUTION_COUNT:
         avg_prior_time = prior_times / prior_execs
         avg_prior_reads = prior_reads / prior_execs

--- a/plan_monitor/detect.py
+++ b/plan_monitor/detect.py
@@ -16,7 +16,7 @@ from . import config, message_schemas, common
 
 logger = logging.getLogger('plan_monitor.detect')
 
-def calculate_plan_age_stats(plan_stats: Dict, stats_time: int) -> Tuple[int, int]:
+def calculate_plan_age_stats(plan_stats: Dict[str, Any], stats_time: int) -> Tuple[int, int]:
     plan_age_seconds = (stats_time - plan_stats['creation_time']) / 1000
     last_exec_age_seconds = (stats_time - plan_stats['last_execution_time']) / 1000
     return (plan_age_seconds, last_exec_age_seconds)
@@ -25,7 +25,7 @@ def is_established_plan(plan_age_seconds: int, last_exec_age_seconds: int) -> bo
     return plan_age_seconds > config.MAX_NEW_PLAN_AGE_SECONDS or \
             last_exec_age_seconds > config.MAX_AGE_OF_LAST_EXECUTION_SECONDS
 
-def is_plan_under_investigation(plan_stats: Dict, stats_time: int) -> bool:
+def is_plan_under_investigation(plan_stats: Dict[str, Any], stats_time: int) -> bool:
     plan_age_seconds, last_exec_age_seconds = calculate_plan_age_stats(plan_stats, stats_time)
     return not is_established_plan(plan_age_seconds, last_exec_age_seconds)
 

--- a/plan_monitor/detect.py
+++ b/plan_monitor/detect.py
@@ -175,7 +175,6 @@ def detect() -> None:
 
                 caught_up = time.time() - (msg_val['stats_query_time'] / 1000) < \
                     config.MAX_ALLOWED_EVALUATION_LAG_SECONDS
-
                 query_key = (msg_key['db_identifier'], msg_key['set_options'], msg_key['sql_handle'])
                 queries[query_key][msg_val['plan_handle']] = msg_val
                 queries[query_key][msg_val['plan_handle']]['source_stats_message_coordinates'] = \

--- a/plan_monitor/detect.py
+++ b/plan_monitor/detect.py
@@ -54,7 +54,7 @@ def find_bad_plans(plans: Dict[str, Dict], stats_time: int) -> Tuple[List[Dict[s
             # too new; ignore entirely for now. If it's a problem we'll catch it on next poll
             continue
         elif is_established_plan(plan_age_seconds, last_exec_age_seconds) and \
-                current_query_plan_hash not in potential_bad_query_plan_hashes:
+            current_query_plan_hash not in potential_bad_query_plan_hashes:
             # this is an old or "established" plan; gather its stats but don't consider it for "badness"
             prior_plans.append(plan_stats)
             prior_plans_count += 1

--- a/tests/DetectTests.py
+++ b/tests/DetectTests.py
@@ -1,4 +1,3 @@
-import os
 import datetime
 from unittest import TestCase, mock
 from plan_monitor import config

--- a/tests/DetectTests.py
+++ b/tests/DetectTests.py
@@ -27,7 +27,7 @@ class CalculatePlanAge(TestCase):
 
 class IsEstablishedPlan(TestCase):
 
-    # test plan established because plan age is sufficiently old
+    # plan is established because plan age is sufficiently old
     @mock.patch('plan_monitor.config')
     def test_is_established_plan_plan_age(self, conf):
         conf.MAX_AGE_OF_LAST_EXECUTION_SECONDS.return_value = 5
@@ -46,7 +46,7 @@ class IsEstablishedPlan(TestCase):
         is_established = is_established_plan(plan_age_seconds, last_execution_time_seconds)
         self.assertTrue(is_established)
 
-    # test plan established because plan execution age is sufficiently old
+    # plan is established because plan execution age is sufficiently old
     @mock.patch('plan_monitor.config')
     def test_is_established_plan_execution_age(self, conf):
         conf.MAX_AGE_OF_LAST_EXECUTION_SECONDS.return_value = 5
@@ -66,7 +66,7 @@ class IsEstablishedPlan(TestCase):
         is_established = is_established_plan(plan_age_seconds, last_execution_time_seconds)
         self.assertTrue(is_established)
     
-    # test plan established because plan execution age and plan age are sufficiently old
+    # plan is established because plan both execution age and plan age are sufficiently old
     @mock.patch('plan_monitor.config')
     def test_is_established_plan_both(self, conf):
         conf.MAX_AGE_OF_LAST_EXECUTION_SECONDS.return_value = 5
@@ -85,6 +85,7 @@ class IsEstablishedPlan(TestCase):
         is_established = is_established_plan(plan_age_seconds, last_execution_time_seconds)
         self.assertTrue(is_established)
 
+    # plan is not established
     @mock.patch('plan_monitor.config')
     def test_is_not_established_plan(self, conf):
         conf.MAX_AGE_OF_LAST_EXECUTION_SECONDS.return_value = 5
@@ -105,6 +106,7 @@ class IsEstablishedPlan(TestCase):
 
 class GetActiveQueryPlanHashes(TestCase):
 
+    # an established query plan hash matches an unestablished plan
     @mock.patch('plan_monitor.config')
     def test_get_query_plan_hash_under_investigation(self, conf):
         conf.MAX_AGE_OF_LAST_EXECUTION_SECONDS.return_value = 5
@@ -134,7 +136,7 @@ class GetActiveQueryPlanHashes(TestCase):
         self.assertEqual(len(qp_hashes_under_investigation), 1)
         self.assertEqual(qp_hashes_under_investigation.pop(), duplicate_query_plan_hash)
 
-
+    # returns a query hash plan even if neither duplicate is established
     @mock.patch('plan_monitor.config')
     def test_get_query_plan_hash_under_investigation_returns_qp_hash(self, conf):
         conf.MAX_AGE_OF_LAST_EXECUTION_SECONDS.return_value = 5
@@ -164,6 +166,7 @@ class GetActiveQueryPlanHashes(TestCase):
         self.assertEqual(len(qp_hashes_under_investigation), 1)
         self.assertEqual(qp_hashes_under_investigation.pop(), duplicate_query_plan_hash)
 
+    # does not return a query plan hash if duplicates are both established
     @mock.patch('plan_monitor.config')
     def test_get_query_plan_hash_under_investigation_doesnt_return_established_plans(self, conf):
         conf.MAX_AGE_OF_LAST_EXECUTION_SECONDS.return_value = 5

--- a/tests/DetectTests.py
+++ b/tests/DetectTests.py
@@ -1,0 +1,195 @@
+import os
+import datetime
+from unittest import TestCase, mock
+from plan_monitor import config
+from plan_monitor.detect import calculate_plan_age_stats, is_established_plan, \
+    get_query_plan_hashes_under_investigation
+
+def get_time_diff_from_ms(start_time: datetime, seconds_to_subtract: int) -> int:
+    ts = start_time - datetime.timedelta(seconds=seconds_to_subtract)
+    return ts.timestamp() * 1000
+ 
+class CalculatePlanAge(TestCase):
+
+    def test_calculate_plan_age(self):
+        plan_stats = {
+            "creation_time": 3234325,
+            "last_execution_time": 324242,
+            "worst_statement_query_plan_hash": "23424252"
+        }
+        dt = datetime.datetime.now()
+        stats_time = int(dt.strftime("%Y%m%d%H%M%S"))
+        plan_age_seconds, last_execution_time_seconds = calculate_plan_age_stats(plan_stats, stats_time)
+        expected_plan_age = (stats_time - plan_stats['creation_time']) / 1000
+        exected_last_execution_age = (stats_time - plan_stats['last_execution_time']) / 1000
+        self.assertEqual(expected_plan_age, plan_age_seconds)
+        self.assertEqual(exected_last_execution_age, last_execution_time_seconds)
+
+class IsEstablishedPlan(TestCase):
+
+    # test plan established because plan age is sufficiently old
+    @mock.patch('plan_monitor.config')
+    def test_is_established_plan_plan_age(self, conf):
+        conf.MAX_AGE_OF_LAST_EXECUTION_SECONDS.return_value = 5
+        conf.MAX_NEW_PLAN_AGE_SECONDS.return_value = 3
+        dt = datetime.datetime.now()
+        stats_time = dt.timestamp() * 1000
+        established_create_ms = get_time_diff_from_ms(dt, (config.MAX_NEW_PLAN_AGE_SECONDS + 1))
+        established_last_execution_ms = get_time_diff_from_ms(dt, (config.MAX_AGE_OF_LAST_EXECUTION_SECONDS - 1))
+        plan_stats = {
+            "creation_time": established_create_ms,
+            "last_execution_time": established_last_execution_ms,
+            "worst_statement_query_plan_hash": "23424252"
+        }
+        
+        plan_age_seconds, last_execution_time_seconds = calculate_plan_age_stats(plan_stats, stats_time)
+        is_established = is_established_plan(plan_age_seconds, last_execution_time_seconds)
+        self.assertTrue(is_established)
+
+    # test plan established because plan execution age is sufficiently old
+    @mock.patch('plan_monitor.config')
+    def test_is_established_plan_execution_age(self, conf):
+        conf.MAX_AGE_OF_LAST_EXECUTION_SECONDS.return_value = 5
+        conf.MAX_NEW_PLAN_AGE_SECONDS.return_value = 3
+        dt = datetime.datetime.now()
+        stats_time = dt.timestamp() * 1000
+        established_create_ms = get_time_diff_from_ms(dt, (config.MAX_NEW_PLAN_AGE_SECONDS - 1))
+        established_last_execution_ms = get_time_diff_from_ms(dt, (config.MAX_AGE_OF_LAST_EXECUTION_SECONDS + 1))
+    
+        plan_stats = {
+            "creation_time": established_create_ms,
+            "last_execution_time": established_last_execution_ms,
+            "worst_statement_query_plan_hash": "23424252"
+        }
+        
+        plan_age_seconds, last_execution_time_seconds = calculate_plan_age_stats(plan_stats, stats_time)
+        is_established = is_established_plan(plan_age_seconds, last_execution_time_seconds)
+        self.assertTrue(is_established)
+    
+    # test plan established because plan execution age and plan age are sufficiently old
+    @mock.patch('plan_monitor.config')
+    def test_is_established_plan_both(self, conf):
+        conf.MAX_AGE_OF_LAST_EXECUTION_SECONDS.return_value = 5
+        conf.MAX_NEW_PLAN_AGE_SECONDS.return_value = 3
+        dt = datetime.datetime.now()
+        stats_time = dt.timestamp() * 1000
+        established_create_ms = get_time_diff_from_ms(dt, (config.MAX_NEW_PLAN_AGE_SECONDS + 1))
+        established_last_execution_ms = get_time_diff_from_ms(dt, (config.MAX_AGE_OF_LAST_EXECUTION_SECONDS + 1))
+        plan_stats = {
+            "creation_time": established_create_ms,
+            "last_execution_time": established_last_execution_ms,
+            "worst_statement_query_plan_hash": "23424252"
+        }
+        
+        plan_age_seconds, last_execution_time_seconds = calculate_plan_age_stats(plan_stats, stats_time)
+        is_established = is_established_plan(plan_age_seconds, last_execution_time_seconds)
+        self.assertTrue(is_established)
+
+    @mock.patch('plan_monitor.config')
+    def test_is_not_established_plan(self, conf):
+        conf.MAX_AGE_OF_LAST_EXECUTION_SECONDS.return_value = 5
+        conf.MAX_NEW_PLAN_AGE_SECONDS.return_value = 3
+        dt = datetime.datetime.now()
+        stats_time = dt.timestamp() * 1000
+        established_create_ms = get_time_diff_from_ms(dt, (config.MAX_NEW_PLAN_AGE_SECONDS - 1))
+        established_last_execution_ms = get_time_diff_from_ms(dt, (config.MAX_AGE_OF_LAST_EXECUTION_SECONDS - 1))
+        plan_stats = {
+            "creation_time": established_create_ms,
+            "last_execution_time": established_last_execution_ms,
+            "worst_statement_query_plan_hash": "23424252"
+        }
+        
+        plan_age_seconds, last_execution_time_seconds = calculate_plan_age_stats(plan_stats, stats_time)
+        is_established = is_established_plan(plan_age_seconds, last_execution_time_seconds)
+        self.assertFalse(is_established)
+
+class GetActiveQueryPlanHashes(TestCase):
+
+    @mock.patch('plan_monitor.config')
+    def test_get_query_plan_hash_under_investigation(self, conf):
+        conf.MAX_AGE_OF_LAST_EXECUTION_SECONDS.return_value = 5
+        conf.MAX_NEW_PLAN_AGE_SECONDS.return_value = 3
+        duplicate_query_plan_hash = '2FCDCA2278D3D2A3'
+        dt = datetime.datetime.now()
+        stats_time = dt.timestamp() * 1000
+        plans = {
+            "plan-one-duplicate-qp-hash-not-established": {
+                "creation_time": get_time_diff_from_ms(dt, (config.MAX_NEW_PLAN_AGE_SECONDS - 1)),
+                "last_execution_time": get_time_diff_from_ms(dt, (config.MAX_AGE_OF_LAST_EXECUTION_SECONDS - 1)),
+                "worst_statement_query_plan_hash": duplicate_query_plan_hash
+            },
+            "not-a-match-established": {
+                "creation_time": get_time_diff_from_ms(dt, (config.MAX_NEW_PLAN_AGE_SECONDS + 1)),
+                "last_execution_time": get_time_diff_from_ms(dt, (config.MAX_AGE_OF_LAST_EXECUTION_SECONDS - 1)),
+                "worst_statement_query_plan_hash": "not-a-query-plan-hash-match"
+            },
+            "plan-two-duplicate-qp-hash-is-established": {
+                "creation_time": get_time_diff_from_ms(dt, (config.MAX_NEW_PLAN_AGE_SECONDS + 2)),
+                "last_execution_time": get_time_diff_from_ms(dt, (config.MAX_AGE_OF_LAST_EXECUTION_SECONDS + 2)),
+                "worst_statement_query_plan_hash": duplicate_query_plan_hash
+            }
+        }
+        
+        qp_hashes_under_investigation = get_query_plan_hashes_under_investigation(plans, stats_time)
+        self.assertEqual(len(qp_hashes_under_investigation), 1)
+        self.assertEqual(qp_hashes_under_investigation.pop(), duplicate_query_plan_hash)
+
+
+    @mock.patch('plan_monitor.config')
+    def test_get_query_plan_hash_under_investigation_returns_qp_hash(self, conf):
+        conf.MAX_AGE_OF_LAST_EXECUTION_SECONDS.return_value = 5
+        conf.MAX_NEW_PLAN_AGE_SECONDS.return_value = 3
+        duplicate_query_plan_hash = '2FCDCA2278D3D2A3'
+        dt = datetime.datetime.now()
+        stats_time = dt.timestamp() * 1000
+        plans = {
+            "plan-one-duplicate-qp-hash-not-established": {
+                "creation_time": get_time_diff_from_ms(dt, (config.MAX_NEW_PLAN_AGE_SECONDS - 1)),
+                "last_execution_time": get_time_diff_from_ms(dt, (config.MAX_AGE_OF_LAST_EXECUTION_SECONDS - 1)),
+                "worst_statement_query_plan_hash": duplicate_query_plan_hash
+            },
+            "not-a-match-established": {
+                "creation_time": get_time_diff_from_ms(dt, (config.MAX_NEW_PLAN_AGE_SECONDS + 1)),
+                "last_execution_time": get_time_diff_from_ms(dt, (config.MAX_AGE_OF_LAST_EXECUTION_SECONDS - 1)),
+                "worst_statement_query_plan_hash": "not-a-query-plan-hash-match"
+            },
+            "plan-two-duplicate-qp-hash-not-established-either": {
+                "creation_time": get_time_diff_from_ms(dt, (config.MAX_NEW_PLAN_AGE_SECONDS - 1)),
+                "last_execution_time": get_time_diff_from_ms(dt, (config.MAX_AGE_OF_LAST_EXECUTION_SECONDS - 1)),
+                "worst_statement_query_plan_hash": duplicate_query_plan_hash
+            }
+        }
+        
+        qp_hashes_under_investigation = get_query_plan_hashes_under_investigation(plans, stats_time)
+        self.assertEqual(len(qp_hashes_under_investigation), 1)
+        self.assertEqual(qp_hashes_under_investigation.pop(), duplicate_query_plan_hash)
+
+    @mock.patch('plan_monitor.config')
+    def test_get_query_plan_hash_under_investigation_doesnt_return_established_plans(self, conf):
+        conf.MAX_AGE_OF_LAST_EXECUTION_SECONDS.return_value = 5
+        conf.MAX_NEW_PLAN_AGE_SECONDS.return_value = 3
+        duplicate_query_plan_hash = '2FCDCA2278D3D2A3'
+        dt = datetime.datetime.now()
+        stats_time = dt.timestamp() * 1000
+        plans = {
+            "plan-one-duplicate-qp-hash-established": {
+                "creation_time": get_time_diff_from_ms(dt, (config.MAX_NEW_PLAN_AGE_SECONDS + 1)),
+                "last_execution_time": get_time_diff_from_ms(dt, (config.MAX_AGE_OF_LAST_EXECUTION_SECONDS + 1)),
+                "worst_statement_query_plan_hash": duplicate_query_plan_hash
+            },
+            "not-a-match-established": {
+                "creation_time": get_time_diff_from_ms(dt, (config.MAX_NEW_PLAN_AGE_SECONDS + 1)),
+                "last_execution_time": get_time_diff_from_ms(dt, (config.MAX_AGE_OF_LAST_EXECUTION_SECONDS - 1)),
+                "worst_statement_query_plan_hash": "not-a-query-plan-hash-match"
+            },
+            "plan-two-duplicate-qp-hash-established-either": {
+                "creation_time": get_time_diff_from_ms(dt, (config.MAX_NEW_PLAN_AGE_SECONDS + 1)),
+                "last_execution_time": get_time_diff_from_ms(dt, (config.MAX_AGE_OF_LAST_EXECUTION_SECONDS + 1)),
+                "worst_statement_query_plan_hash": duplicate_query_plan_hash
+            }
+        }
+        
+        qp_hashes_under_investigation = get_query_plan_hashes_under_investigation(plans, stats_time)
+        self.assertEqual(len(qp_hashes_under_investigation), 0)
+
+


### PR DESCRIPTION
The following PR ejects established plans from the plan performance baseline metrics used to determine plan outliers for a given SQL statement based on query plan hash values. If the query plan hash of an established plan (one that has been created or executed sufficiently long ago) matches one of a plan for which we're intending to assess badness, the established plan's metrics won't be aggregated into the baseline metrics for any of the plans associated with that SQL statement.